### PR TITLE
feat: add search/filter to resources list

### DIFF
--- a/.github/agents.md
+++ b/.github/agents.md
@@ -1,0 +1,94 @@
+# Agents.md – Cyfor AI Workshop
+
+## Project Overview
+
+This is a monorepo for a fullstack workshop application consisting of an **API**, a **Web** frontend, and **Slides**. The app is a simple CRUD item list used as a teaching tool.
+
+## Architecture
+
+```
+cyfor-ai-workshop/
+├── api/          # Backend – Hono + Prisma + SQLite
+├── web/          # Frontend – React + Vite + TailwindCSS
+├── slides/       # Presentation slides
+└── workshop-tasks/  # Workshop task descriptions (task-1 to task-4)
+```
+
+### API (`api/`)
+
+- **Framework:** Hono with `@hono/zod-openapi` for type-safe, OpenAPI-documented routes
+- **ORM:** Prisma with SQLite (`api/data/workshop.db`)
+- **Entry point:** `api/src/index.ts` → creates the HTTP server
+- **App/routes:** `api/src/app.ts` → all route definitions and handlers
+- **Database client:** `api/src/db.ts`
+- **Schema:** `api/prisma/schema.prisma` – single `Item` model (id, title, createdAt)
+- **OpenAPI spec:** Exported to `api/openapi.json` via `api/scripts/export-openapi.ts`
+
+#### API Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/` | Root info |
+| GET | `/health` | Health check |
+| GET | `/items` | List all items (newest first) |
+| POST | `/items` | Create a new item (body: `{ title }`) |
+| DELETE | `/items/{id}` | Delete an item by ID |
+
+### Web (`web/`)
+
+- **Framework:** React 19 + Vite 8
+- **Styling:** TailwindCSS 4
+- **Data fetching:** TanStack React Query + Axios
+- **API client generation:** Orval generates typed hooks from `api/openapi.json` into `web/src/api/generated/hooks.ts`
+- **Custom Axios client:** `web/src/api/client.ts`
+- **Entry point:** `web/src/main.tsx` → `web/src/App.tsx`
+
+### Slides (`slides/`)
+
+- Static HTML presentation (likely reveal.js)
+- Contains Sopra Steria branding assets and diagrams about agents
+
+## Key Commands
+
+| Command | Description |
+|---------|-------------|
+| `npm install` | Install all workspace dependencies |
+| `npm run dev` | Start API (port 3000) and Web (port 5173) concurrently |
+| `npm run dev:api` | Start only the API |
+| `npm run dev:web` | Start only the Web frontend |
+| `npm run generate` | Regenerate Prisma client, OpenAPI spec, and Orval hooks |
+| `npm run build` | Build all workspaces |
+| `npm run typecheck` | Type-check all workspaces |
+
+## Code Conventions
+
+- **Language:** TypeScript (ES modules, `"type": "module"`)
+- **Node.js:** 20+
+- **Package manager:** npm 10+ with npm workspaces
+- **Validation:** Zod schemas define both runtime validation and OpenAPI documentation
+- **API responses** use ISO 8601 datetime strings for dates
+- **CORS:** Configured for `localhost:5173` and `localhost:4173` by default; customizable via `CORS_ORIGIN` env var
+- **API port:** Default 3000, customizable via `API_PORT` env var
+
+## Database
+
+- SQLite file at `api/data/workshop.db` (auto-created on first run)
+- Single model: `Item { id: Int, title: String, createdAt: DateTime }`
+- Migrations in `api/prisma/migrations/`
+- Inspect with `npx prisma studio --schema api/prisma/schema.prisma`
+
+## Code Generation Pipeline
+
+1. Prisma generates the typed database client from `schema.prisma`
+2. `api/scripts/export-openapi.ts` exports the OpenAPI spec to `api/openapi.json`
+3. Orval reads `api/openapi.json` and generates React Query hooks into `web/src/api/generated/hooks.ts`
+
+**Always run `npm run generate` after changing API routes or the Prisma schema.**
+
+## Guidelines for AI Agents
+
+- When modifying API routes, update them in `api/src/app.ts` following the existing pattern: define a Zod schema, create a route with `createRoute()`, then implement the handler with `app.openapi()`.
+- After API changes, run `npm run generate` to regenerate the OpenAPI spec and frontend hooks.
+- After Prisma schema changes, run `npm run generate` and consider creating a migration with `npx prisma migrate dev --schema api/prisma/schema.prisma`.
+- Frontend auto-generated files in `web/src/api/generated/` should **never** be edited manually.
+- Keep the workshop simple — this is a teaching project, not production code.

--- a/.github/skills/pr-review/SKILL.md
+++ b/.github/skills/pr-review/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: pr-review
+description: "Reviews pull requests for code quality, security, and modern TypeScript best practices. Use when reviewing PRs, checking code quality, finding security issues, or ensuring TypeScript best practices. Triggers: PR review, code review, pull request, security review, TypeScript review, code quality."
+compatibility: GitHub Copilot
+---
+
+# PR Review — Concise & Secure TypeScript
+
+Review pull requests with a focus on **concise code**, **security**, and **modern TypeScript** (5.x+).
+
+**Keywords**: PR review, code review, security, TypeScript, best practices, pull request
+
+---
+
+## Review Checklist
+
+### 1. Security
+
+- [ ] **No secrets in code** — API keys, tokens, passwords must come from environment variables or secret managers, never hardcoded.
+- [ ] **Input validation** — All user input (request bodies, query params, URL params) is validated and sanitized. Prefer `zod` schemas.
+- [ ] **SQL injection** — Only parameterized queries or ORM methods (e.g., Prisma). Never string-interpolated SQL.
+- [ ] **XSS** — No `dangerouslySetInnerHTML` or unescaped user content in templates.
+- [ ] **Dependency safety** — Flag new/unfamiliar dependencies. Check for known vulnerabilities.
+- [ ] **Auth & authz** — Ensure protected routes check authentication and authorization. No open endpoints that should be guarded.
+- [ ] **Error handling** — Errors must not leak stack traces, internal paths, or DB details to clients.
+- [ ] **CORS / headers** — Verify CORS config is not `*` in production. Security headers present.
+
+### 2. Modern TypeScript
+
+- [ ] **`satisfies` operator** — Prefer `satisfies` over `as` for type-safe validation without widening.
+- [ ] **`using` declarations** — Use `using` / `await using` for disposable resources (DB connections, file handles).
+- [ ] **`const` type parameters** — Use `<const T>` where literal types should be inferred.
+- [ ] **Strict mode** — `strict: true` in tsconfig. No `any` without explicit justification.
+- [ ] **Narrowing over casting** — Use type guards, `in` operator, or discriminated unions instead of `as`.
+- [ ] **Template literal types** — Prefer template literal types for string patterns over loose `string`.
+- [ ] **`readonly` by default** — Mark arrays and objects as `readonly` unless mutation is required.
+- [ ] **No enums** — Prefer `as const` objects or union types over `enum`.
+
+### 3. Conciseness
+
+- [ ] **No dead code** — Remove commented-out code, unused imports, unreachable branches.
+- [ ] **DRY** — Extract repeated logic into shared functions or constants.
+- [ ] **Early returns** — Use guard clauses to reduce nesting.
+- [ ] **Optional chaining & nullish coalescing** — Use `?.` and `??` instead of verbose null checks.
+- [ ] **Object shorthand** — Use `{ name }` instead of `{ name: name }`.
+- [ ] **Array methods** — Prefer `.map()`, `.filter()`, `.find()` over imperative loops when clearer.
+- [ ] **Destructuring** — Use destructuring for function params and object access.
+
+---
+
+## Review Output Format
+
+For each finding, use this format:
+
+```
+### <severity>: <short title>
+
+**File:** `path/to/file.ts:lineNumber`
+**Category:** Security | TypeScript | Conciseness
+
+<1-2 sentence explanation>
+
+// suggested fix (if applicable)
+```
+
+Severity levels:
+- 🔴 **Critical** — Security vulnerability or data loss risk. Must fix.
+- 🟡 **Warning** — Bug risk, missing types, or non-idiomatic code. Should fix.
+- 🔵 **Suggestion** — Style improvement or modern TS feature opportunity. Nice to have.
+
+---
+
+## Common Anti-Patterns to Flag
+
+| Anti-pattern | Fix |
+|---|---|
+| `as any` / `as unknown as T` | Use proper generics or type guards |
+| `enum Direction { ... }` | `const Direction = { Up: 'up', Down: 'down' } as const` |
+| `if (x !== null && x !== undefined)` | `if (x != null)` or `x ?? fallback` |
+| `try { ... } catch (e) { console.log(e) }` | Typed error handling with `instanceof`, proper logging |
+| `export default` | Prefer named exports for better refactoring |
+| Mutable function params | `(items: readonly string[])` |
+| `Promise` constructor for existing async | Just `return await` or chain `.then()` |
+| `.then().catch()` chains | `async/await` with `try/catch` |
+
+---
+
+## Example Review Comment
+
+```
+### 🔴 Critical: SQL injection via string interpolation
+
+**File:** `api/src/items.ts:42`
+**Category:** Security
+
+User-supplied `category` is interpolated directly into the SQL query.
+Use Prisma's `where` clause or a parameterized query instead.
+
+// Before
+const items = await db.$queryRaw(`SELECT * FROM Item WHERE category = '${category}'`)
+
+// After
+const items = await db.item.findMany({ where: { category } })
+```

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 .idea
 .DS_Store
-.vscode
+.vscode/*
+!.vscode/mcp.json
 dist/

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,9 @@
+{
+  "servers": {
+    "context7": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp@latest"]
+    }
+  }
+}

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -184,6 +184,17 @@
         "tags": [
           "Items"
         ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "example": "workshop"
+            },
+            "required": false,
+            "name": "search",
+            "in": "query"
+          }
+        ],
         "responses": {
           "200": {
             "description": "List persisted items",

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -49,6 +49,17 @@
             "maxLength": 120,
             "example": "Build a workshop API"
           },
+          "description": {
+            "type": "string",
+            "maxLength": 500,
+            "example": "A short description of the resource"
+          },
+          "category": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 60,
+            "example": "general"
+          },
           "createdAt": {
             "type": "string",
             "format": "date-time",
@@ -58,6 +69,8 @@
         "required": [
           "id",
           "title",
+          "description",
+          "category",
           "createdAt"
         ]
       },
@@ -83,11 +96,46 @@
             "minLength": 1,
             "maxLength": 120,
             "example": "Build a workshop API"
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 500,
+            "default": "",
+            "example": "A short description"
+          },
+          "category": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 60,
+            "default": "general",
+            "example": "general"
           }
         },
         "required": [
           "title"
         ]
+      },
+      "UpdateItem": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 120,
+            "example": "Updated title"
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 500,
+            "example": "Updated description"
+          },
+          "category": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 60,
+            "example": "meeting"
+          }
+        }
       }
     },
     "parameters": {}
@@ -198,6 +246,46 @@
         "responses": {
           "204": {
             "description": "Remove a persisted item"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Items"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true,
+              "example": 1
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateItem"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Update a persisted item",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Item"
+                }
+              }
+            }
           }
         }
       }

--- a/api/prisma/migrations/20260423111211_add_description_category/migration.sql
+++ b/api/prisma/migrations/20260423111211_add_description_category/migration.sql
@@ -1,0 +1,15 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Item" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL DEFAULT '',
+    "category" TEXT NOT NULL DEFAULT 'general',
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+INSERT INTO "new_Item" ("createdAt", "id", "title") SELECT "createdAt", "id", "title" FROM "Item";
+DROP TABLE "Item";
+ALTER TABLE "new_Item" RENAME TO "Item";
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -8,7 +8,9 @@ datasource db {
 }
 
 model Item {
-  id        Int      @id @default(autoincrement())
-  title     String
-  createdAt DateTime @default(now())
+  id          Int      @id @default(autoincrement())
+  title       String
+  description String   @default("")
+  category    String   @default("general")
+  createdAt   DateTime @default(now())
 }

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -14,6 +14,8 @@ const HealthResponseSchema = z.object({
 const ItemSchema = z.object({
   id: z.number().int().openapi({ example: 1 }),
   title: z.string().min(1).max(120).openapi({ example: 'Build a workshop API' }),
+  description: z.string().max(500).openapi({ example: 'A short description of the resource' }),
+  category: z.string().min(1).max(60).openapi({ example: 'general' }),
   createdAt: z.string().datetime().openapi({ example: '2024-01-01T00:00:00.000Z' })
 }).openapi('Item')
 
@@ -22,8 +24,16 @@ const ItemListResponseSchema = z.object({
 }).openapi('ItemListResponse')
 
 const CreateItemSchema = z.object({
-  title: z.string().trim().min(1).max(120).openapi({ example: 'Build a workshop API' })
+  title: z.string().trim().min(1).max(120).openapi({ example: 'Build a workshop API' }),
+  description: z.string().trim().max(500).default('').openapi({ example: 'A short description' }),
+  category: z.string().trim().min(1).max(60).default('general').openapi({ example: 'general' })
 }).openapi('CreateItem')
+
+const UpdateItemSchema = z.object({
+  title: z.string().trim().min(1).max(120).optional().openapi({ example: 'Updated title' }),
+  description: z.string().trim().max(500).optional().openapi({ example: 'Updated description' }),
+  category: z.string().trim().min(1).max(60).optional().openapi({ example: 'meeting' })
+}).openapi('UpdateItem')
 
 const ItemParamsSchema = z.object({
   id: z.coerce.number().int().positive().openapi({
@@ -123,9 +133,38 @@ const deleteItemRoute = createRoute({
   }
 })
 
-const toItemResponse = (item: { id: number; title: string; createdAt: Date }) => ({
+const updateItemRoute = createRoute({
+  method: 'put',
+  path: '/items/{id}',
+  tags: ['Items'],
+  request: {
+    params: ItemParamsSchema,
+    body: {
+      required: true,
+      content: {
+        'application/json': {
+          schema: UpdateItemSchema
+        }
+      }
+    }
+  },
+  responses: {
+    200: {
+      description: 'Update a persisted item',
+      content: {
+        'application/json': {
+          schema: ItemSchema
+        }
+      }
+    }
+  }
+})
+
+const toItemResponse = (item: { id: number; title: string; description: string; category: string; createdAt: Date }) => ({
   id: item.id,
   title: item.title,
+  description: item.description,
+  category: item.category,
   createdAt: item.createdAt.toISOString()
 })
 
@@ -178,10 +217,12 @@ app.openapi(listItemsRoute, async (c) => {
 })
 
 app.openapi(createItemRoute, async (c) => {
-  const { title } = c.req.valid('json')
+  const { title, description, category } = c.req.valid('json')
   const item = await prisma.item.create({
     data: {
-      title
+      title,
+      description: description ?? '',
+      category: category ?? 'general'
     }
   })
 
@@ -198,6 +239,18 @@ app.openapi(deleteItemRoute, async (c) => {
   })
 
   return c.body(null, 204)
+})
+
+app.openapi(updateItemRoute, async (c) => {
+  const { id } = c.req.valid('param')
+  const data = c.req.valid('json')
+
+  const item = await prisma.item.update({
+    where: { id },
+    data
+  })
+
+  return c.json(toItemResponse(item), 200)
 })
 
 export type AppType = typeof app

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -77,10 +77,24 @@ const healthRoute = createRoute({
   }
 })
 
+const ItemQuerySchema = z.object({
+  search: z.string().optional().openapi({
+    param: {
+      name: 'search',
+      in: 'query',
+      required: false
+    },
+    example: 'workshop'
+  })
+}).openapi('ItemQuery')
+
 const listItemsRoute = createRoute({
   method: 'get',
   path: '/items',
   tags: ['Items'],
+  request: {
+    query: ItemQuerySchema
+  },
   responses: {
     200: {
       description: 'List persisted items',
@@ -205,7 +219,20 @@ app.openapi(healthRoute, (c) => {
 })
 
 app.openapi(listItemsRoute, async (c) => {
+  const { search } = c.req.valid('query')
+
+  const where = search
+    ? {
+        OR: [
+          { title: { contains: search } },
+          { description: { contains: search } },
+          { category: { contains: search } }
+        ]
+      }
+    : undefined
+
   const items = await prisma.item.findMany({
+    where,
     orderBy: {
       createdAt: 'desc'
     }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -93,11 +93,12 @@ export default function App() {
   const [description, setDescription] = useState("");
   const [category, setCategory] = useState("general");
   const [editingId, setEditingId] = useState<number | null>(null);
+  const [search, setSearch] = useState("");
 
   const queryClient = useQueryClient();
   const refreshItems = () =>
-    queryClient.invalidateQueries({ queryKey: getGetItemsQueryKey() });
-  const itemsQuery = useGetItems();
+    queryClient.invalidateQueries({ queryKey: ["/items"] });
+  const itemsQuery = useGetItems(search ? { search } : undefined);
   const createItemMutation = usePostItems({
     mutation: {
       onSuccess: async () => {
@@ -206,7 +207,15 @@ export default function App() {
         ) : null}
 
         <section className="rounded-lg border border-pink-200 bg-white p-4 shadow-sm">
-          <h2 className="text-sm font-medium text-pink-700">Resources</h2>
+          <div className="flex items-center justify-between gap-3">
+            <h2 className="text-sm font-medium text-pink-700">Resources</h2>
+            <input
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search resources..."
+              className="w-60 rounded-md border border-pink-300 px-3 py-1.5 text-sm outline-none focus:border-pink-500"
+            />
+          </div>
 
           {itemsQuery.isPending ? <p className="mt-3 text-sm text-pink-600">Loading resources...</p> : null}
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,11 +4,96 @@ import {
   useDeleteItemsId,
   useGetItems,
   usePostItems,
+  usePutItemsId,
 } from "./api";
+import type { Item } from "./api";
 import { useQueryClient } from "@tanstack/react-query";
+
+const CATEGORIES = ["general", "meeting", "equipment", "room", "other"] as const;
+
+function EditResourceForm({
+  resource,
+  onCancel,
+  onSaved,
+}: {
+  resource: Item;
+  onCancel: () => void;
+  onSaved: () => void;
+}) {
+  const [title, setTitle] = useState(resource.title);
+  const [description, setDescription] = useState(resource.description);
+  const [category, setCategory] = useState(resource.category);
+
+  const updateMutation = usePutItemsId({
+    mutation: { onSuccess: onSaved },
+  });
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    if (!title.trim() || updateMutation.isPending) return;
+    updateMutation.mutate({
+      id: resource.id,
+      data: { title: title.trim(), description: description.trim(), category },
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-2 rounded-md border border-pink-200 bg-pink-50 p-3">
+      <input
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        placeholder="Title"
+        maxLength={120}
+        className="rounded-md border border-pink-300 px-3 py-1.5 text-sm outline-none focus:border-pink-500"
+      />
+      <textarea
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        placeholder="Description (optional)"
+        maxLength={500}
+        rows={2}
+        className="rounded-md border border-pink-300 px-3 py-1.5 text-sm outline-none focus:border-pink-500"
+      />
+      <select
+        value={category}
+        onChange={(e) => setCategory(e.target.value)}
+        className="rounded-md border border-pink-300 px-3 py-1.5 text-sm outline-none focus:border-pink-500"
+      >
+        {CATEGORIES.map((cat) => (
+          <option key={cat} value={cat}>
+            {cat.charAt(0).toUpperCase() + cat.slice(1)}
+          </option>
+        ))}
+      </select>
+      <div className="flex gap-2">
+        <button
+          type="submit"
+          disabled={!title.trim() || updateMutation.isPending}
+          className="rounded-md bg-pink-600 px-3 py-1 text-sm font-medium text-white disabled:cursor-not-allowed disabled:bg-pink-300"
+        >
+          {updateMutation.isPending ? "Saving..." : "Save"}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-md border border-pink-300 px-3 py-1 text-sm text-pink-700"
+        >
+          Cancel
+        </button>
+      </div>
+      {updateMutation.isError && (
+        <p className="text-sm text-rose-600">Could not update: {updateMutation.error.message}</p>
+      )}
+    </form>
+  );
+}
 
 export default function App() {
   const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [category, setCategory] = useState("general");
+  const [editingId, setEditingId] = useState<number | null>(null);
+
   const queryClient = useQueryClient();
   const refreshItems = () =>
     queryClient.invalidateQueries({ queryKey: getGetItemsQueryKey() });
@@ -17,6 +102,8 @@ export default function App() {
     mutation: {
       onSuccess: async () => {
         setTitle("");
+        setDescription("");
+        setCategory("general");
         await refreshItems();
       },
     },
@@ -41,8 +128,10 @@ export default function App() {
     createItemMutation.mutate({
       data: {
         title: trimmedTitle,
-        },
-      });
+        description: description.trim(),
+        category,
+      },
+    });
   };
 
   const handleRemove = (id: number) => {
@@ -54,77 +143,130 @@ export default function App() {
   };
 
   return (
-    <main className="min-h-screen bg-slate-50 px-4 py-10 text-slate-900">
+    <main className="min-h-screen bg-pink-50 px-4 py-10 text-pink-950">
       <div className="mx-auto max-w-xl space-y-6">
         <header className="space-y-2">
-          <h1 className="text-2xl font-semibold">Workshop items</h1>
-          <p className="text-sm text-slate-600">
-            A simple add and remove list powered by the generated API hooks.
+          <h1 className="text-2xl font-semibold text-pink-900">Resources</h1>
+          <p className="text-sm text-pink-600">
+            Manage your resources – add, edit, and remove them as needed.
           </p>
         </header>
 
         <form
-          className="flex flex-col gap-3 rounded-lg border border-slate-200 bg-white p-4 shadow-sm sm:flex-row"
+          className="flex flex-col gap-3 rounded-lg border border-pink-200 bg-white p-4 shadow-sm"
           onSubmit={handleSubmit}
         >
           <input
             value={title}
             onChange={(event) => setTitle(event.target.value)}
-            placeholder="Add an item"
+            placeholder="Resource title"
             maxLength={120}
-            className="flex-1 rounded-md border border-slate-300 px-3 py-2 text-base outline-none focus:border-slate-500"
+            className="rounded-md border border-pink-300 px-3 py-2 text-base outline-none focus:border-pink-500"
           />
-          <button
-            type="submit"
-            disabled={!trimmedTitle || createItemMutation.isPending}
-            className="rounded-md bg-slate-900 px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:bg-slate-300"
-          >
-            {createItemMutation.isPending ? "Adding..." : "Add item"}
-          </button>
+          <textarea
+            value={description}
+            onChange={(event) => setDescription(event.target.value)}
+            placeholder="Description (optional)"
+            maxLength={500}
+            rows={2}
+            className="rounded-md border border-pink-300 px-3 py-2 text-sm outline-none focus:border-pink-500"
+          />
+          <div className="flex gap-3">
+            <select
+              value={category}
+              onChange={(event) => setCategory(event.target.value)}
+              className="flex-1 rounded-md border border-pink-300 px-3 py-2 text-sm outline-none focus:border-pink-500"
+            >
+              {CATEGORIES.map((cat) => (
+                <option key={cat} value={cat}>
+                  {cat.charAt(0).toUpperCase() + cat.slice(1)}
+                </option>
+              ))}
+            </select>
+            <button
+              type="submit"
+              disabled={!trimmedTitle || createItemMutation.isPending}
+              className="rounded-md bg-pink-600 px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:bg-pink-300"
+            >
+              {createItemMutation.isPending ? "Adding..." : "Add resource"}
+            </button>
+          </div>
         </form>
 
         {createItemMutation.isError ? (
           <p className="text-sm text-rose-600">
-            Could not add the item: {createItemMutation.error.message}
+            Could not add the resource: {createItemMutation.error.message}
           </p>
         ) : null}
 
         {deleteItemMutation.isError ? (
           <p className="text-sm text-rose-600">
-            Could not remove the item: {deleteItemMutation.error.message}
+            Could not remove the resource: {deleteItemMutation.error.message}
           </p>
         ) : null}
 
-        <section className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
-          <h2 className="text-sm font-medium text-slate-700">Items</h2>
+        <section className="rounded-lg border border-pink-200 bg-white p-4 shadow-sm">
+          <h2 className="text-sm font-medium text-pink-700">Resources</h2>
 
-          {itemsQuery.isPending ? <p className="mt-3 text-sm text-slate-600">Loading items...</p> : null}
+          {itemsQuery.isPending ? <p className="mt-3 text-sm text-pink-600">Loading resources...</p> : null}
 
           {itemsQuery.isError ? (
-            <p className="mt-3 text-sm text-rose-600">Could not load items: {itemsQuery.error.message}</p>
+            <p className="mt-3 text-sm text-rose-600">Could not load resources: {itemsQuery.error.message}</p>
           ) : null}
 
           {!itemsQuery.isPending && !itemsQuery.isError ? (
             items.length > 0 ? (
-              <ul className="mt-3 divide-y divide-slate-200">
+              <ul className="mt-3 divide-y divide-pink-200">
                 {items.map((item) => (
-                  <li key={item.id} className="flex items-center justify-between gap-3 py-3">
-                    <span>{item.title}</span>
-                    <button
-                      type="button"
-                      onClick={() => handleRemove(item.id)}
-                      disabled={deleteItemMutation.isPending}
-                      className="rounded-md border border-slate-300 px-3 py-1 text-sm text-slate-700 disabled:cursor-not-allowed disabled:border-slate-200 disabled:text-slate-400"
-                    >
-                      {deleteItemMutation.isPending && deletingItemId === item.id
-                        ? "Removing..."
-                        : "Remove"}
-                    </button>
+                  <li key={item.id} className="py-3">
+                    {editingId === item.id ? (
+                      <EditResourceForm
+                        resource={item}
+                        onCancel={() => setEditingId(null)}
+                        onSaved={() => {
+                          setEditingId(null);
+                          refreshItems();
+                        }}
+                      />
+                    ) : (
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-center gap-2">
+                            <span className="font-medium">{item.title}</span>
+                            <span className="inline-block rounded-full bg-pink-100 px-2 py-0.5 text-xs text-pink-600">
+                              {item.category}
+                            </span>
+                          </div>
+                          {item.description && (
+                            <p className="mt-1 text-sm text-pink-400">{item.description}</p>
+                          )}
+                        </div>
+                        <div className="flex gap-2">
+                          <button
+                            type="button"
+                            onClick={() => setEditingId(item.id)}
+                            className="rounded-md border border-pink-300 px-3 py-1 text-sm text-pink-700"
+                          >
+                            Edit
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => handleRemove(item.id)}
+                            disabled={deleteItemMutation.isPending}
+                            className="rounded-md border border-pink-300 px-3 py-1 text-sm text-pink-700 disabled:cursor-not-allowed disabled:border-pink-200 disabled:text-pink-400"
+                          >
+                            {deleteItemMutation.isPending && deletingItemId === item.id
+                              ? "Removing..."
+                              : "Remove"}
+                          </button>
+                        </div>
+                      </div>
+                    )}
                   </li>
                 ))}
               </ul>
             ) : (
-              <p className="mt-3 text-sm text-slate-600">No items yet.</p>
+              <p className="mt-3 text-sm text-pink-600">No resources yet.</p>
             )
           ) : null}
         </section>

--- a/web/src/api/generated/hooks.ts
+++ b/web/src/api/generated/hooks.ts
@@ -49,6 +49,13 @@ export interface Item {
      * @maxLength 120
      */
   title: string;
+  /** @maxLength 500 */
+  description: string;
+  /**
+     * @minLength 1
+     * @maxLength 60
+     */
+  category: string;
   createdAt: string;
 }
 
@@ -62,6 +69,28 @@ export interface CreateItem {
      * @maxLength 120
      */
   title: string;
+  /** @maxLength 500 */
+  description?: string;
+  /**
+     * @minLength 1
+     * @maxLength 60
+     */
+  category?: string;
+}
+
+export interface UpdateItem {
+  /**
+     * @minLength 1
+     * @maxLength 120
+     */
+  title?: string;
+  /** @maxLength 500 */
+  description?: string;
+  /**
+     * @minLength 1
+     * @maxLength 60
+     */
+  category?: string;
 }
 
 export const get = (
@@ -437,4 +466,63 @@ const {mutation: mutationOptions} = options ?
         TContext
       > => {
       return useMutation(getDeleteItemsIdMutationOptions(options), queryClient);
+    }
+
+export const putItemsId = (
+    id: number,
+    updateItem: UpdateItem,
+ signal?: AbortSignal
+) => {
+
+
+      return customClient<Item>(
+      {url: `/items/${id}`, method: 'PUT',
+      headers: {'Content-Type': 'application/json', },
+      data: updateItem, signal
+    },
+      );
+    }
+
+
+
+export const getPutItemsIdMutationOptions = <TError = ErrorType<unknown>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof putItemsId>>, TError,{id: number;data: UpdateItem}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof putItemsId>>, TError,{id: number;data: UpdateItem}, TContext> => {
+
+const mutationKey = ['putItemsId'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof putItemsId>>, {id: number;data: UpdateItem}> = (props) => {
+          const {id,data} = props ?? {};
+
+          return  putItemsId(id,data,)
+        }
+
+
+
+
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type PutItemsIdMutationResult = NonNullable<Awaited<ReturnType<typeof putItemsId>>>
+    export type PutItemsIdMutationBody = UpdateItem
+    export type PutItemsIdMutationError = ErrorType<unknown>
+
+    export const usePutItemsId = <TError = ErrorType<unknown>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof putItemsId>>, TError,{id: number;data: UpdateItem}, TContext>, }
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof putItemsId>>,
+        TError,
+        {id: number;data: UpdateItem},
+        TContext
+      > => {
+      return useMutation(getPutItemsIdMutationOptions(options), queryClient);
     }

--- a/web/src/api/generated/hooks.ts
+++ b/web/src/api/generated/hooks.ts
@@ -93,6 +93,10 @@ export interface UpdateItem {
   category?: string;
 }
 
+export type GetItemsParams = {
+search?: string;
+};
+
 export const get = (
 
  signal?: AbortSignal
@@ -268,13 +272,14 @@ export function useGetHealth<TData = Awaited<ReturnType<typeof getHealth>>, TErr
 
 
 export const getItems = (
-
+    params?: GetItemsParams,
  signal?: AbortSignal
 ) => {
 
 
       return customClient<ItemListResponse>(
-      {url: `/items`, method: 'GET', signal
+      {url: `/items`, method: 'GET',
+        params, signal
     },
       );
     }
@@ -282,23 +287,23 @@ export const getItems = (
 
 
 
-export const getGetItemsQueryKey = () => {
+export const getGetItemsQueryKey = (params?: GetItemsParams,) => {
     return [
-    `/items`
+    `/items`, ...(params ? [params] : [])
     ] as const;
     }
 
 
-export const getGetItemsQueryOptions = <TData = Awaited<ReturnType<typeof getItems>>, TError = ErrorType<unknown>>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getItems>>, TError, TData>>, }
+export const getGetItemsQueryOptions = <TData = Awaited<ReturnType<typeof getItems>>, TError = ErrorType<unknown>>(params?: GetItemsParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getItems>>, TError, TData>>, }
 ) => {
 
 const {query: queryOptions} = options ?? {};
 
-  const queryKey =  queryOptions?.queryKey ?? getGetItemsQueryKey();
+  const queryKey =  queryOptions?.queryKey ?? getGetItemsQueryKey(params);
 
 
 
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof getItems>>> = ({ signal }) => getItems(signal);
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof getItems>>> = ({ signal }) => getItems(params, signal);
 
 
 
@@ -312,7 +317,7 @@ export type GetItemsQueryError = ErrorType<unknown>
 
 
 export function useGetItems<TData = Awaited<ReturnType<typeof getItems>>, TError = ErrorType<unknown>>(
-  options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof getItems>>, TError, TData>> & Pick<
+ params: undefined |  GetItemsParams, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof getItems>>, TError, TData>> & Pick<
         DefinedInitialDataOptions<
           Awaited<ReturnType<typeof getItems>>,
           TError,
@@ -322,7 +327,7 @@ export function useGetItems<TData = Awaited<ReturnType<typeof getItems>>, TError
  , queryClient?: QueryClient
   ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 export function useGetItems<TData = Awaited<ReturnType<typeof getItems>>, TError = ErrorType<unknown>>(
-  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getItems>>, TError, TData>> & Pick<
+ params?: GetItemsParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getItems>>, TError, TData>> & Pick<
         UndefinedInitialDataOptions<
           Awaited<ReturnType<typeof getItems>>,
           TError,
@@ -332,16 +337,16 @@ export function useGetItems<TData = Awaited<ReturnType<typeof getItems>>, TError
  , queryClient?: QueryClient
   ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 export function useGetItems<TData = Awaited<ReturnType<typeof getItems>>, TError = ErrorType<unknown>>(
-  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getItems>>, TError, TData>>, }
+ params?: GetItemsParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getItems>>, TError, TData>>, }
  , queryClient?: QueryClient
   ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 
 export function useGetItems<TData = Awaited<ReturnType<typeof getItems>>, TError = ErrorType<unknown>>(
-  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getItems>>, TError, TData>>, }
+ params?: GetItemsParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getItems>>, TError, TData>>, }
  , queryClient?: QueryClient
  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
 
-  const queryOptions = getGetItemsQueryOptions(options)
+  const queryOptions = getGetItemsQueryOptions(params,options)
 
   const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
 


### PR DESCRIPTION
## Summary

Add a server-side search/filter feature to the items endpoint and frontend.

### Changes
- **API**: Added optional `search` query parameter to `GET /items` that filters by title, description, and category using Prisma `contains`
- **OpenAPI spec**: Regenerated to include the new query parameter
- **Generated client**: Regenerated orval hooks to accept `GetItemsParams`
- **Frontend**: Added a search input that passes the query to the API for server-side filtering

Closes #7